### PR TITLE
[Feat] TextPatternView 응용매듭 작업 추가

### DIFF
--- a/Dorae/Dorae/Views/Home/Pattern/TextPattern/TextPatternView.swift
+++ b/Dorae/Dorae/Views/Home/Pattern/TextPattern/TextPatternView.swift
@@ -115,15 +115,35 @@ struct TextPatternView: View {
                                 Text("\(subKnot.knotCount)")
                             }
                         }
+                        
+                        if let loop = subKnot.loop, !loop.isEmpty {
+                            LoopListView(loopList: loop) { loop in
+                                knotDataManager.knotList = knotDataManager.knotList.map { knotItem in
+                                    if case Knot.applied(let appliedKnot) = knotItem {
+                                        if let subKnotIndex = appliedKnot.subKnotList.firstIndex(where: { $0.id == subKnot.id }) {
+                                            var updatedSubKnot = subKnot
+                                            updatedSubKnot.loop = loop
+                                            var updatedAppliedKnot = appliedKnot
+                                            updatedAppliedKnot.subKnotList[subKnotIndex] = updatedSubKnot
+                                            return .applied(knot: updatedAppliedKnot)
+                                        } else {
+                                            return knotItem
+                                        }
+                                    }
+                                    return knotItem
+                                }
+                            }
+                            .deleteDisabled(true)
+                        }
                     }
                     .deleteDisabled(true)
                     .moveDisabled(true)
                     
                 }, label: {
                     HStack {
-                        Image(knot.knotName.rawValue+"매듭")
+                        Image("\(knot.knotName)매듭")
                             .resizable()
-                            .frame(width: 42, height: 42)
+                            .frame(width: 50, height: 50)
                         Text(knot.knotName.rawValue)
                     }
                 })
@@ -165,6 +185,7 @@ fileprivate struct LoopListView: View {
     var body: some View {
         ForEach(loopList.indices, id: \.self) { index in
             HStack {
+                Spacer().frame(width: 80)
                 Text("귀")
                 Image(systemName: "\(index+1).circle")
                 TextField("cm", text: $loopList[index])


### PR DESCRIPTION
## 🔥 작업한 내용
- 응용매듭 분기처리
- 응용매듭 subKnotList에 있는 기본 매듭들이 귀가 있을 때, 개수가 있을 때, 둘 다 있을 때 상황에 맞게 처리함 


## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 분기처리 부분에서 재사용 할 수 있는 코드가 있을 거 같은데 봐주시면 감사하겠습니다


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![Simulator Screen Recording - iPad Air 11-inch (M2) - 2024-05-25 at 04 16 10](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A4-HATVIMILHARA/assets/81469446/ac98dc0f-bf20-4fd9-a1c1-e13aeec3bffb)


## 🚨 관련 이슈
- Resolved: #56 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
