### PR TITLE
[Chore] 스플래시 뷰 비디오 컨트롤러 숨기도록 수정

### DIFF
--- a/Dorae/SplashView.swift
+++ b/Dorae/SplashView.swift
@@ -17,7 +17,7 @@ struct SplashView: View {
                 HomeView()
             } else {
                 if let player = viewModel.player {
-                    VideoPlayer(player: player)
+                    VideoPlayerView(player: player)
                         .onAppear {
                             player.play()
                         }
@@ -29,6 +29,20 @@ struct SplashView: View {
                 }
             }
         }
+    }
+}
+struct VideoPlayerView: UIViewControllerRepresentable {
+    var player: AVPlayer
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let controller = AVPlayerViewController()
+        controller.player = player
+        controller.showsPlaybackControls = false
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {
+        // 필요한 경우 업데이트 로직 추가
     }
 }
 


### PR DESCRIPTION
## 🔥 작업한 내용
- 기존의 @nanninnu 가 만든 스플래시 뷰에서 동영상을 재생시켜 보여줘서 비디오 컨트롤러가 그대로 보여져서 중간에 일시정지가 가능했는데, 이를 막기 위해 스플래시 비디오를 보여주는 것을 VideoPlayer가 아니라 VideoPlayerView를 따로 만들어서 내부에서 AVPlayerViewController를 사용하여 비디오 컨트롤러를 안보이도록 하여 수정

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- VideoPlayer를 쓰면 controller를 숨기는게 따로 없는것 같아서 AVPlayerViewController를 쓰는 뷰를 만들어서 사용했습니다~!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #104 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
