### PR TITLE
[Chore] EditButton 활성화 여부에 따라 매듭 리스트 뷰 흐려지게 바꾸기

### DIFF
--- a/Dorae/Dorae/Views/Home/Pattern/PatternView.swift
+++ b/Dorae/Dorae/Views/Home/Pattern/PatternView.swift
@@ -25,7 +25,7 @@ struct PatternView: View {
                     .background(Color.white)
                     .clipShape(RoundedRectangle(cornerRadius: 24))
                     .overlay {
-                        if knotDataManager.knotList.isEmpty {
+                        if pattern.knotList.isEmpty {
                             ZStack {
                                 RoundedRectangle(cornerRadius: 24)
                                     .fill(.black.opacity(0.5))


### PR DESCRIPTION
## 🔥 작업한 내용
- EditButton이 활성화 되었을 때 매듭 리스트 부분에 ZStack이 활성화 되면서 버튼이 안 눌리게 수정하였습니다.


## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 매듭 리스트 부분 불투명도 확인해주세요


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img width="969" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A4-HATVIMILHARA/assets/81469446/28b7f11f-11c8-406b-8526-0ad514e58187">
<img width="1002" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A4-HATVIMILHARA/assets/81469446/3f06e7b0-babf-4ae1-aef1-742400918949">
<img width="1130" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A4-HATVIMILHARA/assets/81469446/e0531fd6-dc2c-45fe-836e-dcd9f0943618">

## 🚨 관련 이슈
- Resolved: #112 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
