### PR TITLE
[Fix] 홈화면 세로 모드 깨지는 문제 해결

### DIFF
--- a/Dorae/Dorae/Views/Home/HomeView.swift
+++ b/Dorae/Dorae/Views/Home/HomeView.swift
@@ -14,17 +14,13 @@ struct HomeView: View {
     @State private var newPattern: Pattern = Pattern(knotList: [], createdAt: .now, title: "제목없음", braid: "")
     
     let columns = [
-        GridItem(.flexible(), alignment: .top),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible()),
-        GridItem(.flexible())
+        GridItem(.adaptive(minimum: 200, maximum: .infinity), alignment: .top)
     ]
     
     var body: some View {
         NavigationStack {
             ScrollView {
-                LazyVGrid(columns: columns) {
+                LazyVGrid(columns: columns, spacing: 16) {
                     NavigationLink(destination: PatternView(pattern: newPattern)) {
                         HomeNewPatternItem()
                             .padding()
@@ -34,7 +30,7 @@ struct HomeView: View {
                         modelContext.insert(newPattern)
                     })
                     
-                    ForEach(patternList, id: \.self) { pattern in
+                    ForEach(patternList) { pattern in
                         NavigationLink(destination: PatternView(pattern: pattern)) {
                             HomePatternItem(pattern: pattern)
                                 .padding()


### PR DESCRIPTION
## 🔥 작업한 내용
- 아카이빙 오류로 세로버전 추가하면서 홈화면 깨지는 문제 해결했습니다


## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 기존에 GridItem을 flexible로 만들어 열 갯수대로 넣어주었는데, 이렇게 되면 세로모드일때 화면이 넘치거나 겹치게 됩니다
- adaptive로 바꾸고 최소 넓이를 지정해 사이즈에 맞게 자동으로 열이 조정되도록 해주었습니다


## 📸 스크린샷
![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-07-04 at 19 41 35](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A4-HATVIMILHARA/assets/58061222/33be2174-2e9f-42ee-8ff1-585b14f87c09)



## 🚨 관련 이슈
- Resolved: #130 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
