### PR TITLE
[Chore] 스플래시 뷰 비디오 재생시 오디오 세션 옵션 설정

### DIFF
--- a/Dorae/Dorae/Splash/PlayerViewModel.swift
+++ b/Dorae/Dorae/Splash/PlayerViewModel.swift
@@ -24,6 +24,15 @@ class PlayerViewModel: ObservableObject {
             self.isVideoFinished = true
         }
     }
+    
+    func setupAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.ambient, options: [.mixWithOthers])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            print("Failed to set audio session category: \(error)")
+        }
+    }
 }
 
 

--- a/Dorae/SplashView.swift
+++ b/Dorae/SplashView.swift
@@ -19,6 +19,7 @@ struct SplashView: View {
                 if let player = viewModel.player {
                     VideoPlayerView(player: player)
                         .onAppear {
+                            viewModel.setupAudioSession()
                             player.play()
                         }
                         .edgesIgnoringSafeArea(.all)


### PR DESCRIPTION
## 🔥 작업한 내용
- AVAudioSession의 카테고리를 .ambient로 설정하여 비디오 재생 시 다른 오디오 재생을 방해하지 않도록 록하고, .mixWithOthers 옵션을 추가하여 다른 오디오와 함께 재생될 수 있도록 함

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 시뮬레이터로는 스플래시 재생시 오디오 멈춤 확인이 안되서 실 기기로 스플래시 뷰 재생시에도 음악 재생이 멈추지 않는것을 확인했습니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


## 🚨 관련 이슈
- Resolved: #138 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
