### PR TITLE
[Feat] #138 다국어 지원

### DIFF
--- a/Dorae/Dorae.xcodeproj/project.pbxproj
+++ b/Dorae/Dorae.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		B51873CD2C02811900BEDFA2 /* HomeNewPatternItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51873CC2C02811900BEDFA2 /* HomeNewPatternItem.swift */; };
 		B51873CF2C0473ED00BEDFA2 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51873CE2C0473ED00BEDFA2 /* Date+.swift */; };
 		B55EE5A52BFDCBBA005A43BC /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55EE5A42BFDCBBA005A43BC /* View+.swift */; };
+		B584C8B52E1A3BEC00EBEECE /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B584C8B42E1A3BEC00EBEECE /* Localizable.xcstrings */; };
+		B584C9052E1A461900EBEECE /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B584C9042E1A461900EBEECE /* String+.swift */; };
+		B584C9072E1A48AA00EBEECE /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B584C9062E1A48AA00EBEECE /* InfoPlist.xcstrings */; };
 		E7549A352BFF4F84004D15AF /* ImagePatternViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7549A342BFF4F84004D15AF /* ImagePatternViewModel.swift */; };
 		E7549A372BFF50AD004D15AF /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7549A362BFF50AD004D15AF /* UIImage+.swift */; };
 		E7549A392BFF50DD004D15AF /* KnotImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7549A382BFF50DD004D15AF /* KnotImageView.swift */; };
@@ -50,6 +53,9 @@
 		B51873CC2C02811900BEDFA2 /* HomeNewPatternItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNewPatternItem.swift; sourceTree = "<group>"; };
 		B51873CE2C0473ED00BEDFA2 /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		B55EE5A42BFDCBBA005A43BC /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		B584C8B42E1A3BEC00EBEECE /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = Localizable.xcstrings; path = Dorae/Utilities/Localizable.xcstrings; sourceTree = SOURCE_ROOT; };
+		B584C9042E1A461900EBEECE /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		B584C9062E1A48AA00EBEECE /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		E7549A342BFF4F84004D15AF /* ImagePatternViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePatternViewModel.swift; sourceTree = "<group>"; };
 		E7549A362BFF50AD004D15AF /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		E7549A382BFF50DD004D15AF /* KnotImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnotImageView.swift; sourceTree = "<group>"; };
@@ -175,6 +181,7 @@
 				E7549A362BFF50AD004D15AF /* UIImage+.swift */,
 				B51873CE2C0473ED00BEDFA2 /* Date+.swift */,
 				B50C91902C40CEFB00B18185 /* AVPlayerViewController+.swift */,
+				B584C9042E1A461900EBEECE /* String+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -190,9 +197,11 @@
 		E7B5F7072BFB3B2A00A1E749 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				B584C8B42E1A3BEC00EBEECE /* Localizable.xcstrings */,
 				FF6D53282C020E4800452809 /* SplashVideo.mp4 */,
 				B50F27102BFB665500BB96F5 /* KnotList */,
 				E7B5F6DE2BF86CB400A1E749 /* Assets.xcassets */,
+				B584C9062E1A48AA00EBEECE /* InfoPlist.xcstrings */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -299,6 +308,7 @@
 			knownRegions = (
 				en,
 				ko,
+				ja,
 			);
 			mainGroup = E7B5F6CC2BF86CB300A1E749;
 			productRefGroup = E7B5F6D62BF86CB300A1E749 /* Products */;
@@ -316,7 +326,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7B5F6E22BF86CB400A1E749 /* Preview Assets.xcassets in Resources */,
+				B584C9072E1A48AA00EBEECE /* InfoPlist.xcstrings in Resources */,
 				FF6D53292C020E4800452809 /* SplashVideo.mp4 in Resources */,
+				B584C8B52E1A3BEC00EBEECE /* Localizable.xcstrings in Resources */,
 				E7B5F6DF2BF86CB400A1E749 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -346,6 +358,7 @@
 				E7B5F7042BFB391500A1E749 /* Pattern.swift in Sources */,
 				E79330E22C1936140070BC4D /* KeyBoardResponder.swift in Sources */,
 				E7B5F70D2BFB3CAA00A1E749 /* PatternView.swift in Sources */,
+				B584C9052E1A461900EBEECE /* String+.swift in Sources */,
 				E7B5F6D92BF86CB300A1E749 /* DoraeApp.swift in Sources */,
 				B55EE5A52BFDCBBA005A43BC /* View+.swift in Sources */,
 				B51873C92C02636500BEDFA2 /* CategoryTabButton.swift in Sources */,
@@ -420,6 +433,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -476,6 +490,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Dorae/Dorae/Extensions/String+.swift
+++ b/Dorae/Dorae/Extensions/String+.swift
@@ -1,0 +1,25 @@
+//
+//  String+.swift
+//  Dorae
+//
+//  Created by Milou on 7/6/25.
+//
+
+import Foundation
+
+extension String {
+    @inlinable static func localized(_ s: String.LocalizationValue) -> String {
+        String(localized: s)
+    }
+    
+    var asLocalizedKnotName: String {
+        if let basicKnot = BasicKnotName(rawValue: self) {
+            return basicKnot.localizedName
+        } else if let appliedKnot = AppliedKnotName(rawValue: self) {
+            return appliedKnot.localizedName
+        } else if let etcKnot = EtcKnotName(rawValue: self) {
+            return etcKnot.localizedName
+        }
+        return self
+    }
+}

--- a/Dorae/Dorae/Model/Knot.swift
+++ b/Dorae/Dorae/Model/Knot.swift
@@ -107,7 +107,7 @@ struct EtcKnot: Identifiable, Hashable, Codable {
         self.lasso = lasso
         self.interval = interval
     }
-
+    
     init(etcKnot: EtcKnot) {
         self.tassel = etcKnot.tassel
         self.lasso = etcKnot.lasso
@@ -137,6 +137,32 @@ enum BasicKnotName: String, CaseIterable, Codable {
     case 가지방석매듭
     case 딸기매듭
     case 석씨매듭
+    
+    var localizedName: String {
+        switch self {
+        case .도래매듭: return .localized("도래매듭")
+        case .귀도래매듭: return .localized("귀도래매듭")
+        case .단추매듭: return .localized("단추매듭")
+        case .가락지매듭: return .localized("가락지매듭")
+        case .생쪽매듭: return .localized("생쪽매듭")
+        case .나비매듭: return .localized("나비매듭")
+        case .거꾸로나비매듭: return .localized("거꾸로나비매듭")
+        case .두벌매화매듭: return .localized("두벌매화매듭")
+        case .세벌매화매듭: return .localized("세벌매화매듭")
+        case .두벌국화매듭: return .localized("두벌국화매듭")
+        case .세벌국화매듭: return .localized("세벌국화매듭")
+        case .네벌국화매듭: return .localized("네벌국화매듭")
+        case .다섯벌국화매듭: return .localized("다섯벌국화매듭")
+        case .병아리매듭: return .localized("병아리매듭")
+        case .잠자리매듭: return .localized("잠자리매듭")
+        case .동심결매듭: return .localized("동심결매듭")
+        case .안경매듭: return .localized("안경매듭")
+        case .장구매듭: return .localized("장구매듭")
+        case .가지방석매듭: return .localized("가지방석매듭")
+        case .딸기매듭: return .localized("딸기매듭")
+        case .석씨매듭: return .localized("석씨매듭")
+        }
+    }
 }
 
 enum AppliedKnotName: String, CaseIterable, Codable {
@@ -146,11 +172,30 @@ enum AppliedKnotName: String, CaseIterable, Codable {
     case 꽃육립매듭
     case 공작매듭
     case 스타매듭
+    
+    var localizedName: String {
+        switch self {
+        case .항아리매듭: return .localized("항아리매듭")
+        case .지게매듭: return .localized("지게매듭")
+        case .육립매듭: return .localized("육립매듭")
+        case .꽃육립매듭: return .localized("꽃육립매듭")
+        case .공작매듭: return .localized("공작매듭")
+        case .스타매듭: return .localized("스타매듭")
+        }
+    }
 }
 
 enum EtcKnotName: String, CaseIterable, Codable {
     case 고
     case 술
     case 간격
+    
+    var localizedName: String {
+        switch self {
+        case .고: return .localized("고")
+        case .술: return .localized("술")
+        case .간격: return .localized("간격")
+        }
+    }
 }
 

--- a/Dorae/Dorae/Resources/Assets.xcassets/기본/Image.imageset/Contents.json
+++ b/Dorae/Dorae/Resources/Assets.xcassets/기본/Image.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Dorae/Dorae/Resources/InfoPlist.xcstrings
+++ b/Dorae/Dorae/Resources/InfoPlist.xcstrings
@@ -1,0 +1,54 @@
+{
+  "sourceLanguage" : "ko",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Bundle display name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dorae"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドレ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "도래"
+          }
+        }
+      }
+    },
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dorea"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dorae"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dorae"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Dorae/Dorae/Utilities/Localizable.xcstrings
+++ b/Dorae/Dorae/Utilities/Localizable.xcstrings
@@ -1,0 +1,825 @@
+{
+  "sourceLanguage" : "ko",
+  "strings" : {
+    "%lld" : {
+
+    },
+    "cm" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cm"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cm"
+          }
+        }
+      }
+    },
+    "가락지매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Garackji(Ring) Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ガラクジ(指輪)結び"
+          }
+        }
+      }
+    },
+    "가지방석매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Branch Cushion Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "枝座布団結び"
+          }
+        }
+      }
+    },
+    "간격" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spacing"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "間隔"
+          }
+        }
+      }
+    },
+    "간격(cm)을 입력해주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter the spacing(cm)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "間隔(cm)を入力してください。"
+          }
+        }
+      }
+    },
+    "갤러리" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gallery"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ギャラリー"
+          }
+        }
+      }
+    },
+    "거꾸로나비매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reverse Butterfly Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "逆蝶結び"
+          }
+        }
+      }
+    },
+    "고" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lasso"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コ(輪縄)"
+          }
+        }
+      }
+    },
+    "공유" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有"
+          }
+        }
+      }
+    },
+    "공작매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peacock Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "孔雀結び"
+          }
+        }
+      }
+    },
+    "귀(cm)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gwi(cm)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "グィ(cm)"
+          }
+        }
+      }
+    },
+    "귀도래매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guidorae Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "グィドレ結び"
+          }
+        }
+      }
+    },
+    "그림 도안" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drawing Pattern"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "絵パターン"
+          }
+        }
+      }
+    },
+    "글 도안" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text Pattern"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字パターン"
+          }
+        }
+      }
+    },
+    "기본" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basic"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基本"
+          }
+        }
+      }
+    },
+    "기타" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Others"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
+          }
+        }
+      }
+    },
+    "꽃육립매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flower Hexagonal Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "花六立結び"
+          }
+        }
+      }
+    },
+    "끈목" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cord"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コルド"
+          }
+        }
+      }
+    },
+    "끈목을 입력해주세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter the cord name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コルドの名前を入力してください。"
+          }
+        }
+      }
+    },
+    "나비매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nabi(Butterfly) Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ナビ(蝶)結び"
+          }
+        }
+      }
+    },
+    "네벌국화매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quadruple Chrysanthemum Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "四重菊花結び"
+          }
+        }
+      }
+    },
+    "다섯벌국화매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quintuple Chrysanthemum Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "五重菊花結び"
+          }
+        }
+      }
+    },
+    "단추매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Button Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタン結び"
+          }
+        }
+      }
+    },
+    "도래매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dorae Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドレ結び"
+          }
+        }
+      }
+    },
+    "도안" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pattern"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パターン"
+          }
+        }
+      }
+    },
+    "동심결매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concentric Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同心結び"
+          }
+        }
+      }
+    },
+    "두벌국화매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double Chrysanthemum Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "二重菊花結び"
+          }
+        }
+      }
+    },
+    "두벌매화매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double Plum Blossom Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "二重梅花結び"
+          }
+        }
+      }
+    },
+    "딸기매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strawberry Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イチゴ結び"
+          }
+        }
+      }
+    },
+    "매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maedeup"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メドゥプ"
+          }
+        }
+      }
+    },
+    "매듭을 눌러 도안을 추가해보세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap a Maedeup to add it to the pattern"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メドゥプをタップしてパターンに追加してください。"
+          }
+        }
+      }
+    },
+    "병아리매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chick Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ひよこ結び"
+          }
+        }
+      }
+    },
+    "삭제" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        }
+      }
+    },
+    "새 매듭 도안\n생성하기" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create New\nKnot Pattern"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しいメドゥプ\nパターンを作成する"
+          }
+        }
+      }
+    },
+    "생쪽매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saengjjok(Ginger) Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "センジョク(生姜)結び"
+          }
+        }
+      }
+    },
+    "석씨매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stone Seed Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "石の種結び"
+          }
+        }
+      }
+    },
+    "세벌국화매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triple Chrysanthemum Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "三重菊花結び"
+          }
+        }
+      }
+    },
+    "세벌매화매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triple Plum Blossom Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "三重梅花結び"
+          }
+        }
+      }
+    },
+    "술" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tassel"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "房飾り"
+          }
+        }
+      }
+    },
+    "스타매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Star Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スター結び"
+          }
+        }
+      }
+    },
+    "스플래시 비디오를 찾을 수 없습니다." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splash Video Not Found"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スプラッシュビデオが見つかりません。"
+          }
+        }
+      }
+    },
+    "안경매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Glasses Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "眼鏡結び"
+          }
+        }
+      }
+    },
+    "육립매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hexagonal Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "六立結び"
+          }
+        }
+      }
+    },
+    "응용" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applied"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "応用"
+          }
+        }
+      }
+    },
+    "이미지를 찾을 수 없습니다." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image Not Found"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像が見つかりません。"
+          }
+        }
+      }
+    },
+    "이스터 에그" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Easter Egg"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イースターエッグ"
+          }
+        }
+      }
+    },
+    "잠자리매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dragonfly Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トンボ結び"
+          }
+        }
+      }
+    },
+    "장구매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Janggu Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "チャング結び"
+          }
+        }
+      }
+    },
+    "제목없음" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Untitled"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無題"
+          }
+        }
+      }
+    },
+    "지게매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jige Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジゲ(背負子)結び"
+          }
+        }
+      }
+    },
+    "항아리매듭" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hang-ari(Jar) Knot"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ハンガリ(甕)結び"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Dorae/Dorae/Utilities/Localizable.xcstrings
+++ b/Dorae/Dorae/Utilities/Localizable.xcstrings
@@ -25,13 +25,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Garackji(Ring) Knot"
+            "value" : "Ring"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ガラクジ(指輪)結び"
+            "value" : "指輪結び"
           }
         }
       }
@@ -41,7 +41,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Branch Cushion Knot"
+            "value" : "Branch Cushion"
           }
         },
         "ja" : {
@@ -105,13 +105,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reverse Butterfly Knot"
+            "value" : "Reverse Butterfly"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "逆蝶結び"
+            "value" : "逆蝶"
           }
         }
       }
@@ -153,13 +153,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Peacock Knot"
+            "value" : "Peacock"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "孔雀結び"
+            "value" : "孔雀"
           }
         }
       }
@@ -185,13 +185,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Guidorae Knot"
+            "value" : "Guidorae"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "グィドレ結び"
+            "value" : "グィドレ"
           }
         }
       }
@@ -265,13 +265,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Flower Hexagonal Knot"
+            "value" : "Flower Hex"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "花六立結び"
+            "value" : "花六立"
           }
         }
       }
@@ -313,13 +313,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nabi(Butterfly) Knot"
+            "value" : "Butterfly"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ナビ(蝶)結び"
+            "value" : "ナビ(蝶)"
           }
         }
       }
@@ -329,13 +329,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Quadruple Chrysanthemum Knot"
+            "value" : "Quadruple Chrysan."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "四重菊花結び"
+            "value" : "四重菊花"
           }
         }
       }
@@ -345,13 +345,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Quintuple Chrysanthemum Knot"
+            "value" : "Quintuple Chrysan."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "五重菊花結び"
+            "value" : "五重菊花"
           }
         }
       }
@@ -361,13 +361,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Button Knot"
+            "value" : "Button"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ボタン結び"
+            "value" : "ボタン"
           }
         }
       }
@@ -377,13 +377,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dorae Knot"
+            "value" : "Dorae"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ドレ結び"
+            "value" : "ドレ"
           }
         }
       }
@@ -409,13 +409,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Concentric Knot"
+            "value" : "Concentric"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同心結び"
+            "value" : "同心"
           }
         }
       }
@@ -425,13 +425,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Double Chrysanthemum Knot"
+            "value" : "Double Chrysan."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "二重菊花結び"
+            "value" : "二重菊花"
           }
         }
       }
@@ -441,13 +441,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Double Plum Blossom Knot"
+            "value" : "Double Plum Blossom"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "二重梅花結び"
+            "value" : "二重梅花"
           }
         }
       }
@@ -457,13 +457,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Strawberry Knot"
+            "value" : "Strawberry"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "イチゴ結び"
+            "value" : "イチゴ"
           }
         }
       }
@@ -505,13 +505,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chick Knot"
+            "value" : "Chick"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ひよこ結び"
+            "value" : "ひよこ"
           }
         }
       }
@@ -553,13 +553,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Saengjjok(Ginger) Knot"
+            "value" : "Ginger"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "センジョク(生姜)結び"
+            "value" : "生姜"
           }
         }
       }
@@ -569,13 +569,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stone Seed Knot"
+            "value" : "Stone Seed"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "石の種結び"
+            "value" : "石の種"
           }
         }
       }
@@ -585,13 +585,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Triple Chrysanthemum Knot"
+            "value" : "Triple Chrysan."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "三重菊花結び"
+            "value" : "三重菊花"
           }
         }
       }
@@ -601,13 +601,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Triple Plum Blossom Knot"
+            "value" : "Triple Plum Blossom"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "三重梅花結び"
+            "value" : "三重梅花"
           }
         }
       }
@@ -633,13 +633,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Star Knot"
+            "value" : "Star"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "スター結び"
+            "value" : "スター"
           }
         }
       }
@@ -665,13 +665,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Glasses Knot"
+            "value" : "Glasses"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "眼鏡結び"
+            "value" : "眼鏡"
           }
         }
       }
@@ -681,13 +681,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hexagonal Knot"
+            "value" : "Hexagonal"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "六立結び"
+            "value" : "六立"
           }
         }
       }
@@ -745,13 +745,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dragonfly Knot"
+            "value" : "Dragonfly"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "トンボ結び"
+            "value" : "トンボ"
           }
         }
       }
@@ -761,13 +761,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Janggu Knot"
+            "value" : "Janggu"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "チャング結び"
+            "value" : "チャング"
           }
         }
       }
@@ -793,13 +793,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Jige Knot"
+            "value" : "Jige"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ジゲ(背負子)結び"
+            "value" : "ジゲ(背負子)"
           }
         }
       }
@@ -809,13 +809,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hang-ari(Jar) Knot"
+            "value" : "Hang-ari(Jar)"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ハンガリ(甕)結び"
+            "value" : "ハンガリ(甕)"
           }
         }
       }

--- a/Dorae/Dorae/Views/Home/HomeNewPatternItem.swift
+++ b/Dorae/Dorae/Views/Home/HomeNewPatternItem.swift
@@ -12,8 +12,7 @@ struct HomeNewPatternItem: View {
         VStack(spacing: 0) {
             Image(systemName: "plus")
                 .padding(.bottom, 12)
-            Text("새 매듭 도안")
-            Text("생성하기")
+            Text("새 매듭 도안\n생성하기")
         }
         .frame(width: 160, height: 180)
             .clipShape(

--- a/Dorae/Dorae/Views/Home/HomeView.swift
+++ b/Dorae/Dorae/Views/Home/HomeView.swift
@@ -11,7 +11,7 @@ import SwiftData
 struct HomeView: View {
     @Query(sort: \Pattern.createdAt, order: .reverse) var patternList: [Pattern]
     @Environment(\.modelContext) private var modelContext
-    @State private var newPattern: Pattern = Pattern(knotList: [], createdAt: .now, title: "제목없음", braid: "")
+    @State private var newPattern: Pattern = Pattern(knotList: [], createdAt: .now, title: .localized("제목없음"), braid: "")
     
     let columns = [
         GridItem(.adaptive(minimum: 200, maximum: .infinity), alignment: .top)
@@ -26,7 +26,7 @@ struct HomeView: View {
                             .padding()
                     }
                     .simultaneousGesture(TapGesture().onEnded {
-                        newPattern = Pattern(knotList: [], createdAt: .now, title: "제목없음", braid: "")
+                        newPattern = Pattern(knotList: [], createdAt: .now, title: .localized("제목없음"), braid: "")
                         modelContext.insert(newPattern)
                     })
                     

--- a/Dorae/Dorae/Views/Home/Pattern/ImagePattern/KnotImageView.swift
+++ b/Dorae/Dorae/Views/Home/Pattern/ImagePattern/KnotImageView.swift
@@ -38,7 +38,7 @@ struct KnotImageView: View {
                 .frame(width: boundingBox.height)
                 .frame(height: getHeight(for: knot, boundingBox: boundingBox))
             } else {
-                Text("Image not found")
+                Text("이미지를 찾을 수 없습니다.")
             }
         }
     }

--- a/Dorae/Dorae/Views/Home/Pattern/KnotList/KnotButton.swift
+++ b/Dorae/Dorae/Views/Home/Pattern/KnotList/KnotButton.swift
@@ -18,7 +18,7 @@ struct KnotButton: View {
                 .clipShape(RoundedRectangle(cornerRadius: 16))
             Spacer()
                 .frame(height: 8)
-            Text("\(knotName)")
+            Text(knotName.asLocalizedKnotName)
                 .font(.caption)
         }
     }

--- a/Dorae/Dorae/Views/Home/Pattern/KnotList/KnotListView.swift
+++ b/Dorae/Dorae/Views/Home/Pattern/KnotList/KnotListView.swift
@@ -37,15 +37,15 @@ struct KnotListView: View {
         
             
             VStack(spacing: 0) {
-                CategoryTabButton(title: "기본", isSelected: selectedTab == .basicCategory) {
+                CategoryTabButton(title: .localized("기본"), isSelected: selectedTab == .basicCategory) {
                     selectedTab = .basicCategory
                 }
                 
-                CategoryTabButton(title: "응용", isSelected: selectedTab == .appliedCategory) {
+                CategoryTabButton(title: .localized("응용"), isSelected: selectedTab == .appliedCategory) {
                     selectedTab = .appliedCategory
                 }
                 
-                CategoryTabButton(title: "기타", isSelected: selectedTab == .etcCategory) {
+                CategoryTabButton(title: .localized("기타"), isSelected: selectedTab == .etcCategory) {
                     selectedTab = .etcCategory
                 }
                 Spacer()

--- a/Dorae/Dorae/Views/Home/Pattern/TextPattern/TextKnotListView.swift
+++ b/Dorae/Dorae/Views/Home/Pattern/TextPattern/TextKnotListView.swift
@@ -101,7 +101,7 @@ struct TextKnotListView: View {
                 Image("\(knot.knotName)버튼")
                     .resizable()
                     .scaledToFit()
-                Text(knot.knotName.rawValue)
+                Text(knot.knotName.localizedName)
             }
         }
     }
@@ -151,7 +151,7 @@ struct TextKnotListView: View {
                     Image("\(knot.knotName)버튼")
                         .resizable()
                         .scaledToFit()
-                    Text(knot.knotName.rawValue)
+                    Text(knot.knotName.localizedName)
                 }
             }
         }
@@ -208,7 +208,7 @@ struct TextKnotListView: View {
                 Image("\(EtcKnotName.고.rawValue)버튼")
                     .resizable()
                     .scaledToFit()
-                Text(lasso)
+                Text(EtcKnotName.고.localizedName)
             }
         }
         
@@ -217,7 +217,7 @@ struct TextKnotListView: View {
                 Image("\(EtcKnotName.술.rawValue)버튼")
                     .resizable()
                     .scaledToFit()
-                Text(tassel)
+                Text(EtcKnotName.술.localizedName)
             }
         }
     }

--- a/Dorae/SplashView.swift
+++ b/Dorae/SplashView.swift
@@ -24,7 +24,7 @@ struct SplashView: View {
                         }
                         .edgesIgnoringSafeArea(.all)
                 } else {
-                    Text("Splash video not found")
+                    Text("스플래시 비디오를 찾을 수 없습니다.")
                         .foregroundColor(.red)
                         .edgesIgnoringSafeArea(.all)
                 }


### PR DESCRIPTION
## 🔥 작업한 내용
- 다국어 지원을 추가했습니다. 현재 한국어, 영어, 일본어를 지원합니다.
- 길이 이슈로 영어, 일본어로 번역하면서 뒤에 매듭 삭제했습니다 예) 도래매듭 -> Dorae
- 추후 작업: 스크린샷 보시면 영어랑 일본어에서 레이아웃이 다 깨지고 있습니다,, 새로운 브랜치에서 작업할 예정입니다

## ⭐️ PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
1. String Extension 추가
- String+.swift에 기존 .localized() 익스텐션 활용
- 매듭 이름 다국어 변환을 위한 asLocalizedKnotName 속성 추가

2. Knot Models 업데이트
- BasicKnotName, AppliedKnotName, EtcKnotName enum에 localizedName computed property 추가
- 각 매듭 이름에 .localized() 적용

3. UI 컴포넌트 업데이트
- TextKnotListView.swift: 모든 매듭 이름 표시 부분을 localizedName으로 변경
- KnotButton.swift: 매듭 버튼 텍스트에 다국어 지원 적용

4. Localizable.xcstrings 업데이트
- 총 30개 매듭 이름의 한영일 번역 추가
- 위키피디아 및 한국 문화 기관 자료 참고하여 정확한 번역 적용


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
 <img width="300" alt="" src="https://github.com/user-attachments/assets/8ab44cf6-1619-488f-8e4b-de6283e1257f">  
 <img width="300" alt="" src="https://github.com/user-attachments/assets/7c0ac5dd-d47f-48a3-b7c6-2ec07f61e578">  

## 🚨 관련 이슈
- Resolved: #138 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
